### PR TITLE
Allow abosolute paths as well.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ This libary is not intended to use independently outside broccoli or broccoli-pl
 * appendFileSync
 * mkdirSync
 * unlinkSync
+* symlinkSync
+* utimesSync
 
 All these operations above are same as File Operations documented in node API [guide](https://nodejs.org/api/fs.html).
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "broccoli-output-wrapper",
-  "version": "3.1.1",
+  "version": "3.2.0",
   "description": "Output wrapper is a library to write output file to outputpath.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/test/unit-test.js
+++ b/test/unit-test.js
@@ -21,10 +21,9 @@ describe('output-wrapper', function() {
     expect(content).to.be.equal('test');
   });
 
-  it(`throws actionable error when absolute path is provided`, function() {
-    expect(() => output.writeFileSync(`${temp.name}/test.md`, 'test')).to.throw(
-      `Relative path is expected, path ${temp.name}/test.md is an absolute path.`
-    );
+  it(`takes absolute path as input`, function() {
+    output.writeFileSync('test.md', 'test');
+    expect(output.existsSync(`${temp.name}/test.md`, 'test')).to.be.true;
   });
 
   it(`throws actionable error when relative path is traverses above outputPath`, function() {
@@ -35,7 +34,7 @@ describe('output-wrapper', function() {
 
   it(`should not allow other fs operations`, function() {
     expect(() => output.writevSync('test.md', 'test')).to.throw(
-      /^Operation writevSync is not allowed to use. Allowed operations are readFileSync,existsSync,lstatSync,readdirSync,statSync,writeFileSync,appendFileSync,rmdirSync,mkdirSync,unlinkSync,symlinkOrCopySync$/
+      /^Operation writevSync is not allowed to use. Allowed operations are readFileSync,existsSync,lstatSync,readdirSync,statSync,writeFileSync,appendFileSync,rmdirSync,mkdirSync,unlinkSync,symlinkOrCopySync,symlinkSync,utimesSync$/
     );
   });
 


### PR DESCRIPTION
Absolute path access will allow us to use it outside broccoli-plugins
Ex: in node-fs-updater:  customFS method to perform write operations